### PR TITLE
v0.0.10 Compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,5 @@ description = "An abstraction over TCP and struct serialization"
 [dependencies]
 bincode = "*"
 rustc-serialize = "*"
-
-[dependencies.unreliable-message]
-path = "../unreliable-message"
-
-[dependencies.bchannel]
-path = "../bchannel"
+unreliable-message = "0.0.2"
+bchannel = "0.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ description = "An abstraction over TCP and struct serialization"
 [dependencies]
 bincode = "*"
 rustc-serialize = "*"
-unreliable-message = "0.0.2"
+unreliable-message = "0.0.1"
 bchannel = "0.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,9 @@ description = "An abstraction over TCP and struct serialization"
 [dependencies]
 bincode = "*"
 rustc-serialize = "*"
-unreliable-message = "0.0.1"
-bchannel = "0.0.9"
+
+[dependencies.unreliable-message]
+git = "https://github.com/TyOverby/unreliable-message.git"
+
+[dependencies.bchannel]
+git = "https://github.com/TyOverby/bchannel.git"

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -43,7 +43,7 @@ where A: ToSocketAddrs, I: serialize::Encodable, O: serialize::Decodable + Send 
     let sock_2 = try!(sock_1.try_clone());
 
     let back_send = unre::Sender::from_socket(sock_1, message_size, 1);
-    let back_recv = unre::Receiver::from_socket(sock_2, message_size);
+    let back_recv = unre::Receiver::from_socket(sock_2, message_size, None, unre::network::ReceiverFilter::empty_blacklist());
 
     let (in_s, in_r) = channel();
     let (out_s, out_r) = channel();


### PR DESCRIPTION
I am unable to compile version 0.0.9 of wire because I am on a later version of rustc (1.0.0) after some RFC changes. I also could not compile 0.0.10 because of API changes in unreliable message. Now I have it compiling and it seems to work.

I really want to use this crate for a project of mine, there doesn't seem to be anything else like it on crates.io. I'm wondering if 0.0.10 is in a usable state, and if not is there any easy fixes I can submit?
